### PR TITLE
Adds explicit annotation to allow strict mode invocation

### DIFF
--- a/angular-appinsights.js
+++ b/angular-appinsights.js
@@ -17,7 +17,7 @@
 
                 if (appInsights && appId && appInsights.start) {
                     appInsights.start(appId);
-                } 
+                }
 				if (appInsights && appId && !appInsights.start)
 				{
 				    appInsights=appInsights({ instrumentationKey: appId });
@@ -28,10 +28,10 @@
             function Insights () {
 
                 var _logEvent = function (event, properties, property) {
-                    
+
                     if (appInsights && _appId && appInsights.logEvent) {
                         appInsights.logEvent(event, properties, property);
-                    } 
+                    }
 					if (appInsights && _appId && appInsights.trackEvent){
 					    appInsights.trackEvent(event, properties, property);
 					}
@@ -39,7 +39,7 @@
                 },
 
                 _logPageView = function (page) {
-                    
+
                     if (appInsights && _appId && appInsights.logPageView) {
                         appInsights.logPageView(page);
                     }
@@ -74,6 +74,6 @@
                     insights.logPageView(pagePath);
                 }
             });
-        });
+        }]);
 
 }());

--- a/angular-appinsights.js
+++ b/angular-appinsights.js
@@ -63,7 +63,7 @@
 
         })
 
-        .run(function($rootScope, $route, $location, insights) {
+        .run(['$rootScope', '$route', '$location', 'insights', function ($rootScope, $route, $location, insights) {
             $rootScope.$on('$locationChangeSuccess', function() {
                 var pagePath;
                 try {


### PR DESCRIPTION
I've seen this covered off in another more complicated pull request which is still awaiting merging, so thought I'd get this in there as it would have saved me some time when integrating this module. 

Simply adds explicit annotations to run `.run` call to allow strict mode.
