### PR TITLE
Update location of script in bower.json's main field

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-appinsights",
-  "main": "angular-appinsights.js",
+  "main": "dist/angular-appinsights.js",
   "version": "0.0.4",
   "homepage": "https://github.com/johnhidey/angular-appinsights",
   "authors": [


### PR DESCRIPTION
Between 0.0.3 and 0.0.4, the location of angular-appinsights.js in the package moved from the package root to the "dist" folder. However, bower.json's "main" field was not updated to reflect the new location. This breaks builds where the build tool (e.g., webpack) uses "main" to find the package's entry point(s).

This pull request updates bower.json's "main" field to point to the new location (dist/angular-appinsights.js).